### PR TITLE
Avoid errors on indkey 0 and the column is unparsed

### DIFF
--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -188,7 +188,11 @@ module SchemaValidations
 
         def has_case_insensitive_index?(column, scope)
           indexed_columns = (scope + [column.name]).map(&:to_sym).sort
-          index = column.indexes.select { |i| i.unique && i.columns.map(&:to_sym).sort == indexed_columns }.first
+          index = column.indexes.select do |i|
+            !i.columns.is_a?(String) &&
+              i.unique &&
+              i.columns.map(&:to_sym).sort == indexed_columns
+          end.first
 
           index && index.respond_to?(:case_sensitive?) && !index.case_sensitive?
         end


### PR DESCRIPTION
When this happens we get a string instead of an array in the indexes
in the columns slot. Current code does not handle that well.